### PR TITLE
マウントポイントを利用したPython開発

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM python:3
 
-COPY src/requirements.txt /src/requirements.txt
+WORKDIR app
+
+COPY src/requirements.txt /app/src/requirements.txt
 
 RUN pip install -r src/requirements.txt
 
-COPY src /src
-COPY images /images
-
-ENTRYPOINT ["python", "src/rekognition.py"]
+CMD python

--- a/README.md
+++ b/README.md
@@ -10,11 +10,20 @@ cp src/aws.json.sample src/aws.json
 
 aws.jsonにAWSのアクセスキー・アクセスシークレットを記入
 
-### 起動
-
 ```
 docker build -t rekognition .
-docker run rekognition images/sample.jpg
 ```
 
-ソースコードの更新・画像の更新ごとにbuildから実行する必要あり
+### 起動
+
+Dockerコンテナで起動しているPython Shellにログイン
+
+```
+docker run -it -w /app -v $(pwd):/app rekognition bash
+```
+
+Pythonプログラムを実行
+
+```
+python src/rekognition.py images/sample.jpg
+```


### PR DESCRIPTION
前回のPR https://github.com/t-morisawa/rekognition/pull/2 では、ソースコードを変更するたびにビルドし直す必要があった。

今回はWin/Mac共通で使える開発環境が欲しかっただけなので、以下を参考にPythonの開発環境を構築した。

https://qiita.com/Tadahiro_Yamamura/items/df21487286d7cf8bfb6e

これにより、ビルドのし直しは不要になるはず。

また、ボリュームではなくマウントポイントを利用している。これで古いファイルが残り続けることもなさそう。